### PR TITLE
Bump CircleCI setup_remote_docker and add Authentication using org-global context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,23 @@
----
+# GLOBAL-ANCHORS - DockerHub Authentication changes applied - PROD-1431 / PROD-1435
+global_dockerhub_login: &global_dockerhub_login
+  run:
+    name: Authenticate with hub.docker.com - DockerHub
+    command: docker login -u $GLOBAL_DOCKERHUB_USERNAME -p $GLOBAL_DOCKERHUB_PASSWORD
+global_context: &global_context
+  context:
+    - org-global
+global_remote_docker: &global_remote_docker
+  version: 19.03.13
+global_dockerhub_auth: &global_dockerhub_auth
+  auth:
+    username: $GLOBAL_DOCKERHUB_USERNAME
+    password: $GLOBAL_DOCKERHUB_PASSWORD
 version: 2
 
 defaults: &defaults
   docker:
   - image: deliveroo/circleci:0.2.2
+    <<: *global_dockerhub_auth
 
 workflows:
   version: 2
@@ -24,10 +38,11 @@ jobs:
 
     steps:
     - setup_remote_docker:
-        version: 17.09.0-ce
+        <<: *global_remote_docker
         reusable: true
         docker_layer_caching: true
 
+    - *global_dockerhub_login
     - checkout
 
     - run: make clean
@@ -52,6 +67,7 @@ jobs:
     - TARGET: platform
 
     steps:
+      - *global_dockerhub_login
       - checkout
 
       - attach_workspace:


### PR DESCRIPTION
PROD-1435: Changes relating to enforcing Docker Hub authentication on CircleCI

- Enforces all actions using Docker Hub to use authentication (not anonymous)
  using CircleCI Global Context - org-global

- Changes Docker setup_remote_docker version to be updated to 19.03.13 due to
  deprecation from CircleCI of older versions

